### PR TITLE
bugfix to handle empty deepview predict array

### DIFF
--- a/skyline-vscode/react-ui/src/App.js
+++ b/skyline-vscode/react-ui/src/App.js
@@ -103,12 +103,14 @@ function App() {
         setConnectionStatus(event.data["status"]);
       } else if (event.data["message_type"] === "analysis") {
         if (
-          event.data.habitat[0][0] === "unavailable" &&
-          event.data.habitat[0][1] === -1.0
+          event.data.habitat.length === 0 ||
+          (event.data.habitat[0][0] === "unavailable" &&
+            event.data.habitat[0][1] === -1.0)
         ) {
           event.data.habitat = profiling_data.habitat;
           event.data.habitat.push(["demo", 1]);
         }
+        console.log(event.data);
         processAnalysisState(event.data);
       } else if (event.data["message_type"] === "text_change") {
         setTextChanged(true);

--- a/skyline-vscode/react-ui/src/sections/Habitat.js
+++ b/skyline-vscode/react-ui/src/sections/Habitat.js
@@ -14,11 +14,11 @@ export default function Habitat({ habitatData }) {
     return (
       <>
         <div className="innpv-memory innpv-subpanel">
-          <Subheader icon="database">Habitat</Subheader>
+          <Subheader icon="database">DeepView.Predict</Subheader>
           <div className="innpv-subpanel-content">
             <Container fluid className="mt-2">
               <Row className="justify-content-md-center">
-                <h6>The local GPU is not supported by DeepView.Predict</h6>
+                <h6>The local GPU is not supported by DeepView.Predict or DeepView.Predict is not installed</h6>
               </Row>
             </Container>
           </div>
@@ -30,7 +30,7 @@ export default function Habitat({ habitatData }) {
   return (
     <>
       <div className="innpv-memory innpv-subpanel">
-        <Subheader icon="database">Habitat</Subheader>
+        <Subheader icon="database">DeepView.Predict</Subheader>
         <div className="innpv-subpanel-content">
           {habitatData.length === 0 ? (
             <Container fluid>

--- a/skyline-vscode/react-ui/src/sections/ProviderPanel.js
+++ b/skyline-vscode/react-ui/src/sections/ProviderPanel.js
@@ -176,7 +176,7 @@ const ProviderPanel = ({ numIterations, habitatData, additionalProviders }) => {
               <Row className="mt-2">
                 <Alert variant="danger">
                   Currently showing a demo data because local GPU is not
-                  supported by DeepView.Predict
+                  supported by DeepView.Predict or DeepView.Predict is not installed 
                 </Alert>
               </Row>
             )}


### PR DESCRIPTION
- Small bug fix for when the backend is only using DeepView.Profiler without predict. (habitat array is empty)