### PR TITLE
Check if operation_tree has data before access

### DIFF
--- a/deepview-explore/react-ui/src/App.js
+++ b/deepview-explore/react-ui/src/App.js
@@ -84,7 +84,7 @@ function App() {
 
   const processAnalysisState = function (state) {
     setAnalysisState(state);
-    if (state.breakdown) {
+    if (state.breakdown && state.breakdown.operation_tree) {
       let operation_tree = state.breakdown.operation_tree;
       let { coarse, fine } = getTraceByLevel(operation_tree);
       setTimeBreakdown({


### PR DESCRIPTION
- Ensure operation_tree is not empty before accessing it.
- This fixes the error found in the screenshot below
![image](https://user-images.githubusercontent.com/8242605/236555008-13ed86cd-dedd-431c-bfef-d8fd1206dcc0.png)
- This bug was annoying to track down so I will improve the debugging process in a future PR
