### PR TITLE
Fixed protoc version in the build CI

### DIFF
--- a/.github/workflows/build-vsix.yaml
+++ b/.github/workflows/build-vsix.yaml
@@ -23,7 +23,9 @@ jobs:
           node-version: 18
       
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v2
+        with:
+          version: 3.12.6
 
       - name: Install VSCE
         run: |

--- a/deepview-explore/package.json
+++ b/deepview-explore/package.json
@@ -20,8 +20,7 @@
     "Profiling"
   ],
   "activationEvents": [
-    "onStartupFinished",
-    "onCommand: deepview-explore.cmd_begin_analyze"
+    "onStartupFinished"
   ],
   "main": "./out/main.js",
   "contributes": {


### PR DESCRIPTION
A bug was introduced in protoc v3.19 (https://github.com/protocolbuffers/protobuf/pull/9156) so we need to fix the protoc version to make sure the build CI does not use this buggy version